### PR TITLE
18-Add-way-to-add-a-logger-only-if-not-already-existing

### DIFF
--- a/src/TinyLogger-Tests/TinyFileLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyFileLoggerTest.class.st
@@ -27,6 +27,11 @@ TinyFileLoggerTest >> tearDown [
 ]
 
 { #category : #test }
+TinyFileLoggerTest >> testCanHaveDefaultFile [
+	self shouldnt: [ self actualClass new fileReference ] raise: Error
+]
+
+{ #category : #test }
 TinyFileLoggerTest >> testClearLogger [
 	log := (self fileNameNumber: 1) asFileReference.
 	logger := self actualClass for: parentLogger named: log basename.

--- a/src/TinyLogger-Tests/TinyLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyLoggerTest.class.st
@@ -91,6 +91,57 @@ TinyLoggerTest >> testClearLogger [
 ]
 
 { #category : #test }
+TinyLoggerTest >> testEnsureFileLogger [
+	logger removeAllLoggers.
+	self assert: logger loggers isEmpty.
+
+	logger ensureFileLogger.
+	self assert: logger loggers size equals: 1.
+	self assert: logger fileLoggers size equals: 1.
+
+	logger ensureFileLogger.
+	self assert: logger loggers size equals: 1.
+	self assert: logger fileLoggers size equals: 1
+]
+
+{ #category : #test }
+TinyLoggerTest >> testEnsureFileLoggerNamed [
+	logger removeAllLoggers.
+	self assert: logger loggers isEmpty.
+
+	logger ensureFileLoggerNamed: 'test.log'.
+	self assert: logger fileLoggers size equals: 1.
+
+	logger ensureFileLoggerNamed: 'test.log'.
+	logger ensureFileLoggerNamed: 'test2.log'.
+	self assert: logger fileLoggers size equals: 2
+]
+
+{ #category : #test }
+TinyLoggerTest >> testEnsureStdoutLogger [
+	logger removeAllLoggers.
+	self assert: logger loggers isEmpty.
+
+	logger
+		ensureStdoutLogger;
+		ensureStdoutLogger.
+	self assert: logger loggers size equals: 1.
+	self assert: logger stdoutLoggers size equals: 1
+]
+
+{ #category : #test }
+TinyLoggerTest >> testEnsureTranscriptLogger [
+	logger removeAllLoggers.
+	self assert: logger loggers isEmpty.
+	
+	logger
+		ensureTranscriptLogger;
+		ensureTranscriptLogger.
+	self assert: logger loggers size equals: 1.
+	self assert: logger transcriptLoggers size equals: 1
+]
+
+{ #category : #test }
 TinyLoggerTest >> testExecuteRecordedAs [
 	| contents stream bool |
 	self skipInPharo6.

--- a/src/TinyLogger-Tests/TinyStdoutLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyStdoutLoggerTest.class.st
@@ -14,7 +14,7 @@ TinyStdoutLoggerTest >> actualClass [
 
 { #category : #test }
 TinyStdoutLoggerTest >> testClearLogger [
-	"Do nothing because stdio cannot be clear"
+	self shouldnt: [ logger clearLogger ] raise: Error
 ]
 
 { #category : #test }

--- a/src/TinyLogger/TinyFileLogger.class.st
+++ b/src/TinyLogger/TinyFileLogger.class.st
@@ -31,6 +31,11 @@ Class {
 	#category : #'TinyLogger-Core'
 }
 
+{ #category : #accessing }
+TinyFileLogger class >> defaultFileName [
+	^ 'TinyLogger.log'
+]
+
 { #category : #'instance creation' }
 TinyFileLogger class >> for: aLogger named: aString [
 	^ (self for: aLogger)
@@ -56,8 +61,13 @@ TinyFileLogger >> clearLogger [
 ]
 
 { #category : #accessing }
+TinyFileLogger >> defaultFileName [
+	^ self class defaultFileName
+]
+
+{ #category : #accessing }
 TinyFileLogger >> fileName [
-	^ fileName ifNil: [ fileName := 'TinyLogger.log' ]
+	^ fileName ifNil: [ fileName := self defaultFileName ]
 ]
 
 { #category : #accessing }

--- a/src/TinyLogger/TinyLogger.class.st
+++ b/src/TinyLogger/TinyLogger.class.st
@@ -152,6 +152,32 @@ TinyLogger >> depth: anObject [
 ]
 
 { #category : #'public API' }
+TinyLogger >> ensureFileLogger [
+	"Ensure a file logger to `TinyLogger.log` is in the logger. In case one already exists, does nothing."
+
+	self ensureFileLoggerNamed: TinyFileLogger defaultFileName
+]
+
+{ #category : #'public API' }
+TinyLogger >> ensureFileLoggerNamed: aString [
+	"Ensure a file logger to a file whose name is given as parameter is in the logger. In case one already exists, does nothing."
+
+	self fileLoggers
+		detect: [ :e | e fileName = aString ]
+		ifNone: [ self addFileLoggerNamed: aString ]
+]
+
+{ #category : #'public API' }
+TinyLogger >> ensureStdoutLogger [
+	self stdoutLoggers ifEmpty: [ self addStdoutLogger ]
+]
+
+{ #category : #'public API' }
+TinyLogger >> ensureTranscriptLogger [
+	self transcriptLoggers ifEmpty: [ self addTranscriptLogger ]
+]
+
+{ #category : #'public API' }
 TinyLogger >> execute: aBlock recordedAs: aString [
 	self increaseDepthLevel.
 	self record: 'Begin: ' , aString.


### PR DESCRIPTION
Add #ensure* for all loggers kind.

Fixes #18