### PR TITLE
23-Do-not-depend-on-whole-Mocketry

### DIFF
--- a/src/BaselineOfTinyLogger/BaselineOfTinyLogger.class.st
+++ b/src/BaselineOfTinyLogger/BaselineOfTinyLogger.class.st
@@ -34,5 +34,9 @@ BaselineOfTinyLogger >> baseline: spec [
 
 { #category : #dependencies }
 BaselineOfTinyLogger >> mocketry: spec [
-	spec baseline: 'Mocketry' with: [ spec repository: 'github://dionisiydk/Mocketry:v4.0.x' ]
+	spec
+		baseline: 'Mocketry'
+		with: [ spec
+				loads: #('Core');
+				repository: 'github://dionisiydk/Mocketry:v4.0.x' ]
 ]


### PR DESCRIPTION
Depend only on the core of Mocketry for tests.

Fixes #23