### PR TITLE
27-Update-Mocketry-dependency-to-v60x

### DIFF
--- a/src/BaselineOfTinyLogger/BaselineOfTinyLogger.class.st
+++ b/src/BaselineOfTinyLogger/BaselineOfTinyLogger.class.st
@@ -38,5 +38,5 @@ BaselineOfTinyLogger >> mocketry: spec [
 		baseline: 'Mocketry'
 		with: [ spec
 				loads: #('Core');
-				repository: 'github://dionisiydk/Mocketry:v4.0.x' ]
+				repository: 'github://dionisiydk/Mocketry:v6.0.x' ]
 ]


### PR DESCRIPTION
Migrate to Mocketry v6.0.x

Fixes #27