### PR TITLE
keep-right-identation-on-error

### DIFF
--- a/src/TinyLogger-Tests/TinyLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyLoggerTest.class.st
@@ -192,6 +192,37 @@ No time : 	End: This is a new test
 ]
 
 { #category : #test }
+TinyLoggerTest >> testExecuteRecordedAsKeepRightIndentation [
+	| contents stream |
+	self skipInPharo6.
+	logger
+		timestampFormatBlock: [ :s | s nextPutAll: 'No time' ];
+		removeAllLoggers;
+		addStdoutLogger.
+	stream := '' writeStream.
+	[ Stdio stub stdout willReturn: stream.
+	TinyCurrentLogger
+		value: logger
+		during: [ [ Object new execute: [ Error signal ] recordedAs: 'This is a new test' ]
+				on: Error
+				do: [ "nothing" ].
+			Object new execute: [ 'test' record ] recordedAs: 'This is a new test' ].
+	contents := Stdio stdout contents asString.
+	"Ensure we have the right indentation."
+	self
+		assert: contents withUnixLineEndings
+		equals:
+			'No time : 	Begin: This is a new test
+No time : 	End with error: This is a new test
+No time : 	Begin: This is a new test
+No time : 		test
+No time : 	End: This is a new test
+' withUnixLineEndings ]
+		ensure: [ Stdio recoverFromGHMutation.
+			stream close ]
+]
+
+{ #category : #test }
 TinyLoggerTest >> testFileLoggers [
 	logger
 		addTranscriptLogger;

--- a/src/TinyLogger/TinyLogger.class.st
+++ b/src/TinyLogger/TinyLogger.class.st
@@ -184,7 +184,11 @@ TinyLogger >> execute: aBlock recordedAs: aString [
 	self increaseDepthLevel.
 	self record: 'Begin: ' , aString.
 	self increaseDepthLevel.
-	aBlock cull: aString.
+	[ aBlock cull: aString ]
+		ifCurtailed: [ "If there is an error, we ensure we keep the right indentation and we print an end of action with error."
+			self decreaseDepthLevel.
+			self record: 'End with error: ' , aString.
+			self decreaseDepthLevel ].
 	self decreaseDepthLevel.
 	self record: 'End: ' , aString.
 	self decreaseDepthLevel


### PR DESCRIPTION
Improve error management.

When there is an error, still log the end of the action + use right indentation.