### PR TITLE
Add `open` method that open the logs in the dedicated windows

### DIFF
--- a/src/TinyLogger/TinyFileLogger.class.st
+++ b/src/TinyLogger/TinyFileLogger.class.st
@@ -92,6 +92,11 @@ TinyFileLogger >> fileStreamDo: aBlock [
 			aBlock value: s ]
 ]
 
+{ #category : #opening }
+TinyFileLogger >> open [
+	TinyOpenTerminalVisitor openTerminalForFileLogger: self
+]
+
 { #category : #logging }
 TinyFileLogger >> record: aString [
 	self fileStreamDo: [ :aStream | self record: aString on: aStream ]

--- a/src/TinyLogger/TinyLeafLogger.class.st
+++ b/src/TinyLogger/TinyLeafLogger.class.st
@@ -62,6 +62,11 @@ TinyLeafLogger >> newLine [
 	^ OSPlatform current lineEnding
 ]
 
+{ #category : #opening }
+TinyLeafLogger >> open [
+	self subclassResponsibility
+]
+
 { #category : #accessing }
 TinyLeafLogger >> parentLogger [
 	^ parentLogger

--- a/src/TinyLogger/TinyLogger.class.st
+++ b/src/TinyLogger/TinyLogger.class.st
@@ -110,12 +110,16 @@ TinyLogger >> addFileLogger [
 
 { #category : #'public API' }
 TinyLogger >> addFileLoggerNamed: aString [
-	self addLogger: (TinyFileLogger named: aString)
+	^ self addLogger: (TinyFileLogger named: aString)
 ]
 
 { #category : #'public API' }
 TinyLogger >> addLogger: aLogger [
-	(self loggersMap at: aLogger kind ifAbsentPut: [ OrderedCollection new ]) add: (aLogger parentLogger: self)
+
+	^ (self loggersMap
+		 at: aLogger kind
+		 ifAbsentPut: [ OrderedCollection new ]) add:
+		(aLogger parentLogger: self)
 ]
 
 { #category : #'public API' }
@@ -164,7 +168,7 @@ TinyLogger >> ensureFileLogger [
 TinyLogger >> ensureFileLoggerNamed: aString [
 	"Ensure a file logger to a file whose name is given as parameter is in the logger. In case one already exists, does nothing."
 
-	self fileLoggers
+	^ self fileLoggers
 		detect: [ :e | e fileName = aString ]
 		ifNone: [ self addFileLoggerNamed: aString ]
 ]

--- a/src/TinyLogger/TinyOpenTerminalVisitor.class.st
+++ b/src/TinyLogger/TinyOpenTerminalVisitor.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #TinyOpenTerminalVisitor,
+	#superclass : #OSPlatformVisitor,
+	#instVars : [
+		'logger'
+	],
+	#category : #'TinyLogger-System'
+}
+
+{ #category : #'as yet unclassified' }
+TinyOpenTerminalVisitor class >> openTerminalForFileLogger: aTinyFileLogger [
+
+	^ self new
+		  logger: aTinyFileLogger;
+		  visit
+]
+
+{ #category : #accessing }
+TinyOpenTerminalVisitor >> logger [
+
+	^ logger
+]
+
+{ #category : #accessing }
+TinyOpenTerminalVisitor >> logger: anObject [
+
+	logger := anObject
+]
+
+{ #category : #accessing }
+TinyOpenTerminalVisitor >> visitWindows: aPlatform [
+
+	LibC runCommand:
+		'start powershell -noexit -noprofil -command "& { Get-Content -wait '
+		, self logger fileReference pathString , ' }"'
+]

--- a/src/TinyLogger/TinyTranscriptLogger.class.st
+++ b/src/TinyLogger/TinyTranscriptLogger.class.st
@@ -28,6 +28,11 @@ TinyTranscriptLogger >> clearLog [
 	Transcript clear
 ]
 
+{ #category : #opening }
+TinyTranscriptLogger >> open [
+	Transcript open
+]
+
 { #category : #logging }
 TinyTranscriptLogger >> record: aString [
 	Transcript trace: (String streamContents: [ :s | self record: aString on: s ])


### PR DESCRIPTION
I added the abstract `open` method on `TinyLeafLogger` logger.
Sending `open` to a TinyLeafLogger open the tool that allows one to visualize the logs.

For the Transcript, it opens a Transcript

For the file, it opens a terminal that prints the logs of the file continuously.
I created a `TinyOpenTerminalVisitor` to deal with Windows / Mac / Linux differences. Currently, only Windows is supported.
I would accept the PR with only Window supported and add more support in the futur.