### PR TITLE
Lazy execute recorded as block

### DIFF
--- a/src/TinyLogger-Tests/TinyLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyLoggerTest.class.st
@@ -551,13 +551,13 @@ TinyLoggerTest >> testTranscriptLoggers [
 { #category : 'tests' }
 TinyLoggerTest >> testValueDuringRestoresOriginalLogger [
 
-	self assert: TinyCurrentLogger value identicalTo: logger.
+	self assert: TinyCurrentLogger value equals: logger.
 
 	TinyCurrentLogger
 		value: TinyLogger new
-		during: [ self deny: TinyCurrentLogger value identicalTo: logger ].
+		during: [ self deny: TinyCurrentLogger value equals: logger ].
 
-	self assert: TinyCurrentLogger value identicalTo: logger
+	self assert: TinyCurrentLogger value equals: logger
 ]
 
 { #category : 'tests' }

--- a/src/TinyLogger-Tests/TinyLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyLoggerTest.class.st
@@ -200,6 +200,36 @@ No time : 	End: This is a new test
 ]
 
 { #category : 'tests' }
+TinyLoggerTest >> testExecuteRecordedAsBlock [
+	| log |
+	self skipInPharo6.
+	log := 'testFileForTinyLogger.log' asFileReference.
+	[
+
+	logger execute: [  ] recordedAs: [ 'this is a test' ].
+
+	self deny: log exists ]
+		ensure: [ (log isNotNil and: [ log exists ])
+				ifTrue: [ log ensureDelete ] ]
+]
+
+{ #category : 'tests' }
+TinyLoggerTest >> testExecuteRecordedAsBlock2 [
+	| log |
+	self skipInPharo6.
+	log := 'testFileForTinyLogger.log' asFileReference.
+	[
+	logger addFileLoggerNamed: log basename.
+
+	logger execute: [  ] recordedAs: [ 'this is a test' ].
+
+	self assert: log exists.
+	self assert: (log contents includesSubstring: 'this is a test') ]
+		ensure: [ (log isNotNil and: [ log exists ])
+				ifTrue: [ log ensureDelete ] ]
+]
+
+{ #category : 'tests' }
 TinyLoggerTest >> testExecuteRecordedAsKeepRightIndentation [
 
 	| contents stream errorDetected |
@@ -386,7 +416,7 @@ TinyLoggerTest >> testRecordBlock [
 	| log |
 	log := 'testFileForTinyLogger.log' asFileReference.
 	[
-	TinyCurrentLogger value: logger during: [ logger record: [ self fail ] ].
+	logger record: [ self fail ].
 
 	self deny: log exists ]
 		ensure: [ (log isNotNil and: [ log exists ])
@@ -400,7 +430,7 @@ TinyLoggerTest >> testRecordBlock2 [
 	[
 	logger addFileLoggerNamed: log basename.
 
-	TinyCurrentLogger value: logger during: [ logger record: [ 'this is a test' ] ].
+	logger record: [ 'this is a test' ].
 
 	self assert: log exists.
 	self assert: (log contents includesSubstring: 'this is a test') ]
@@ -413,7 +443,7 @@ TinyLoggerTest >> testRecordBlockReceiver [
 	| log |
 	log := 'testFileForTinyLogger.log' asFileReference.
 	[
-	TinyCurrentLogger value: logger during: [ [ self fail ] record ].
+	[ self fail ] record.
 
 	self deny: log exists ]
 		ensure: [ (log isNotNil and: [ log exists ])
@@ -427,7 +457,7 @@ TinyLoggerTest >> testRecordBlockReceiver2 [
 	[
 	logger addFileLoggerNamed: log basename.
 
-	TinyCurrentLogger value: logger during: [ [ 'this is a test' ] record ].
+	[ 'this is a test' ] record.
 
 	self assert: log exists.
 	self assert: (log contents includesSubstring: 'this is a test') ]

--- a/src/TinyLogger-Tests/TinyLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyLoggerTest.class.st
@@ -184,7 +184,7 @@ TinyLoggerTest >> testExecuteRecordedAs2 [
 		addStdoutLogger.
 	stream := '' writeStream.
 	[ Stdio stub stdout willReturn: stream.
-	TinyCurrentLogger value: logger during: [ Object new execute: [ 'test' record ] recordedAs: 'This is a new test' ].
+	Object new execute: [ 'test' record ] recordedAs: 'This is a new test'.
 	contents := Stdio stdout contents asString.
 
 	"Ensure we have the right indentation."
@@ -205,7 +205,6 @@ TinyLoggerTest >> testExecuteRecordedAsBlock [
 	self skipInPharo6.
 	log := 'testFileForTinyLogger.log' asFileReference.
 	[
-
 	logger execute: [  ] recordedAs: [ 'this is a test' ].
 
 	self deny: log exists ]
@@ -240,22 +239,21 @@ TinyLoggerTest >> testExecuteRecordedAsKeepRightIndentation [
 		removeAllLoggers;
 		addStdoutLogger.
 	stream := '' writeStream.
-	[ 
+	[
 	Stdio stub stdout willReturn: stream.
-	TinyCurrentLogger value: logger during: [ 
-		[ Object new execute: [ Error signal: 'test' ] recordedAs: 'This is a new test' ]
-			on: Error
-			do: [ errorDetected := true ].
-		Object new execute: [ 'test' record ] recordedAs: 'This is a new test' ].
+	[ Object new execute: [ Error signal: 'test' ] recordedAs: 'This is a new test' ]
+		on: Error
+		do: [ errorDetected := true ].
+	Object new execute: [ 'test' record ] recordedAs: 'This is a new test'.
 	contents := Stdio stdout contents asString.
 	"Ensure we have the right indentation."
 	self assert: errorDetected.
 	self assert: contents withUnixLineEndings equals: 'No time : 	Begin: This is a new test
-No time : 	End with error: This is a new test.Error message: "Error: test"
+No time : 	End with error: This is a new test. Error message: "Error: test"
 No time : 	Begin: This is a new test
 No time : 		test
 No time : 	End: This is a new test
-' withUnixLineEndings ] ensure: [ 
+' withUnixLineEndings ] ensure: [
 		Stdio recoverFromGHMutation.
 		stream close ]
 ]
@@ -402,7 +400,7 @@ TinyLoggerTest >> testRecord3 [
 	[
 	logger addFileLoggerNamed: log basename.
 	
-	TinyCurrentLogger value: logger during: [ 'this is a test' record ].
+	'this is a test' record.
 	
 	self assert: log exists.
 	self assert: log contents lines isNotEmpty.
@@ -548,6 +546,18 @@ TinyLoggerTest >> testTranscriptLoggers [
 	self assert: logger loggers size equals: 3.
 	self assert: logger transcriptLoggers size equals: 2.
 	self assert: (logger transcriptLoggers allSatisfy: [ :each | each kind = TinyTranscriptLogger kind ])
+]
+
+{ #category : 'tests' }
+TinyLoggerTest >> testValueDuringRestoresOriginalLogger [
+
+	self assert: TinyCurrentLogger value identicalTo: logger.
+
+	TinyCurrentLogger
+		value: TinyLogger new
+		during: [ self deny: TinyCurrentLogger value identicalTo: logger ].
+
+	self assert: TinyCurrentLogger value identicalTo: logger
 ]
 
 { #category : 'tests' }

--- a/src/TinyLogger-Tests/TinyLoggerTest.class.st
+++ b/src/TinyLogger-Tests/TinyLoggerTest.class.st
@@ -550,14 +550,15 @@ TinyLoggerTest >> testTranscriptLoggers [
 
 { #category : 'tests' }
 TinyLoggerTest >> testValueDuringRestoresOriginalLogger [
+	"Do not use assert/deny:identicalTo: for compatibility with Pharo 6"
 
-	self assert: TinyCurrentLogger value equals: logger.
+	self assert: TinyCurrentLogger value == logger.
 
 	TinyCurrentLogger
 		value: TinyLogger new
-		during: [ self deny: TinyCurrentLogger value equals: logger ].
+		during: [ self deny: TinyCurrentLogger value == logger ].
 
-	self assert: TinyCurrentLogger value equals: logger
+	self assert: TinyCurrentLogger value == logger
 ]
 
 { #category : 'tests' }

--- a/src/TinyLogger/Object.extension.st
+++ b/src/TinyLogger/Object.extension.st
@@ -1,8 +1,8 @@
 Extension { #name : 'Object' }
 
 { #category : '*TinyLogger' }
-Object >> execute: aBlock recordedAs: aString [
-	^ TinyCurrentLogger value execute: aBlock recordedAs: aString
+Object >> execute: aBlock recordedAs: aBlockOrString [
+	^ TinyCurrentLogger value execute: aBlock recordedAs: aBlockOrString
 ]
 
 { #category : '*TinyLogger' }
@@ -11,6 +11,6 @@ Object >> record [
 ]
 
 { #category : '*TinyLogger' }
-Object >> record: aString [
-	TinyCurrentLogger value record: aString
+Object >> record: aBlockOrString [
+	TinyCurrentLogger value record: aBlockOrString
 ]

--- a/src/TinyLogger/TinyLogger.class.st
+++ b/src/TinyLogger/TinyLogger.class.st
@@ -191,26 +191,31 @@ TinyLogger >> ensureTranscriptLogger [
 ]
 
 { #category : 'public API' }
-TinyLogger >> execute: aBlock recordedAs: aString [
+TinyLogger >> execute: aBlock recordedAs: aBlockOrString [
 
-	| result errorMessage |
+	| logMessage result errorMessage |
+	logMessage := aBlockOrString isBlock
+		              ifTrue: [ aBlockOrString value ]
+		              ifFalse: [ aBlockOrString ].
+	self hasLoggers ifFalse: [ ^ aBlock cull: logMessage ].
+
 	self increaseDepthLevel.
-	self record: 'Begin: ' , aString.
+	self record: 'Begin: ' , logMessage.
 	self increaseDepthLevel.
-	[ 
-	[ result := aBlock cull: aString ]
+	[
+	[ result := aBlock cull: logMessage ]
 		on: Error
 		do: [ :exception | "If there is an error, we keep the message and pass it. The message will be used in the #ifCurtailed: to ensure we keep the right indentation and print a better result to the user."
 			errorMessage := exception printString.
 			exception pass ] ] ifCurtailed: [ "If there is an unexpected termination of the execution, print that there was an error."
 		self decreaseDepthLevel.
-		self record: 'End with error: ' , aString , '.' , (errorMessage
+		self record: 'End with error: ' , logMessage , '.' , (errorMessage
 				 ifNil: [ '' ]
-				 ifNotNil: [ 'Error message: "' , errorMessage , '"' ]).
+				 ifNotNil: [ ' Error message: "' , errorMessage , '"' ]).
 		self decreaseDepthLevel ].
 
 	self decreaseDepthLevel.
-	self record: 'End: ' , aString.
+	self record: 'End: ' , logMessage.
 	self decreaseDepthLevel.
 	^ result
 ]


### PR DESCRIPTION
Similar to #47
Add lazy behavior to `TinyLogger>>#execute:recordedAs:` such that:
- If no loggers are set, then the `execute` block runs immediately.
- The second argument can be a block that will only be evaluated if necessary.

In addition:
- Rename arg `aString` to `aBlockOrString` where applicable.
- Add space before error message when `execute:recordedAs:` is interrupted.
- Remove use of `value:during:` in TinyLoggerTest, since it is now done in `performTest`.
- Add a test for `value:during:` to check that the previous logger is restored.